### PR TITLE
Fixed issue "NextCloud tries to connect to https://localhost:31000/"

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,9 +1,41 @@
-#sub_path_only rewrite ^__PATH__$ __PATH__/ permanent;
-location __PATH__ {
 
-  proxy_pass https://localhost:__PORT__;
-  proxy_read_timeout 30s;
+location / {
 
-  # Include SSOWAT user panel.
-  include conf.d/yunohost_panel.conf.inc;
+rewrite  ^/$  https://__DOMAIN__/loleaflet/dist/admin/admin.html permanent;
+    # static files
+    location ^~ /loleaflet {
+        proxy_pass http://localhost:__PORT__;
+        proxy_set_header Host $http_host;
+    }
+
+    # WOPI discovery URL
+    location ^~ /hosting/discovery {
+        proxy_pass http://localhost:__PORT__;
+        proxy_set_header Host $http_host;
+    }
+
+    # Main websocket
+    location ~ /lool/(.*)/ws$ {
+        proxy_pass http://localhost:__PORT__;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_set_header Host $http_host;
+        proxy_read_timeout 36000s;
+    }
+
+    # Admin Console websocket
+    location ^~ /lool/adminws {
+        proxy_pass http://localhost:__PORT__;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_set_header Host $http_host;
+        proxy_read_timeout 36000s;
+    }
+
+    # download, presentation and image upload
+    location ^~ /lool {
+        proxy_pass http://localhost:__PORT__;
+        proxy_set_header Host $http_host;
+    }
+ 
 }

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -4,19 +4,19 @@ location / {
 rewrite  ^/$  https://__DOMAIN__/loleaflet/dist/admin/admin.html permanent;
     # static files
     location ^~ /loleaflet {
-        proxy_pass http://localhost:__PORT__;
+        proxy_pass https://localhost:__PORT__;
         proxy_set_header Host $http_host;
     }
 
     # WOPI discovery URL
     location ^~ /hosting/discovery {
-        proxy_pass http://localhost:__PORT__;
+        proxy_pass https://localhost:__PORT__;
         proxy_set_header Host $http_host;
     }
 
     # Main websocket
     location ~ /lool/(.*)/ws$ {
-        proxy_pass http://localhost:__PORT__;
+        proxy_pass https://localhost:__PORT__;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
         proxy_set_header Host $http_host;
@@ -25,7 +25,7 @@ rewrite  ^/$  https://__DOMAIN__/loleaflet/dist/admin/admin.html permanent;
 
     # Admin Console websocket
     location ^~ /lool/adminws {
-        proxy_pass http://localhost:__PORT__;
+        proxy_pass https://localhost:__PORT__;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
         proxy_set_header Host $http_host;
@@ -34,7 +34,7 @@ rewrite  ^/$  https://__DOMAIN__/loleaflet/dist/admin/admin.html permanent;
 
     # download, presentation and image upload
     location ^~ /lool {
-        proxy_pass http://localhost:__PORT__;
+        proxy_pass https://localhost:__PORT__;
         proxy_set_header Host $http_host;
     }
  

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,41 +1,19 @@
+# static files
+location ^~ /loleaflet {
+    proxy_pass https://localhost:__PORT__;
+    proxy_set_header Host $http_host;
+}
 
-location / {
+# WOPI discovery URL
+location ^~ /hosting/discovery {
+    proxy_pass https://localhost:__PORT__;
+    proxy_set_header Host $http_host;
+}
 
-rewrite  ^/$  https://__DOMAIN__/loleaflet/dist/admin/admin.html permanent;
-    # static files
-    location ^~ /loleaflet {
-        proxy_pass https://localhost:__PORT__;
-        proxy_set_header Host $http_host;
-    }
-
-    # WOPI discovery URL
-    location ^~ /hosting/discovery {
-        proxy_pass https://localhost:__PORT__;
-        proxy_set_header Host $http_host;
-    }
-
-    # Main websocket
-    location ~ /lool/(.*)/ws$ {
-        proxy_pass https://localhost:__PORT__;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
-        proxy_set_header Host $http_host;
-        proxy_read_timeout 36000s;
-    }
-
-    # Admin Console websocket
-    location ^~ /lool/adminws {
-        proxy_pass https://localhost:__PORT__;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
-        proxy_set_header Host $http_host;
-        proxy_read_timeout 36000s;
-    }
-
-    # download, presentation and image upload
-    location ^~ /lool {
-        proxy_pass https://localhost:__PORT__;
-        proxy_set_header Host $http_host;
-    }
- 
+# websockets, download, presentation and image upload
+location ^~ /lool {
+    proxy_pass https://localhost:__PORT__;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $http_host;
 }

--- a/scripts/docker/run.sh
+++ b/scripts/docker/run.sh
@@ -15,7 +15,9 @@ do
 done
 domaines=$(echo $domaines | sed 's/^|//g');
 
-options="-p $port:9980 -e domain=$domaines --cap-add MKNOD"
+server_name=$(ynh_app_setting_get "$app" domain)
+
+options="-p $port:9980 -e domain=$domaines -e server_name=$server_name --cap-add MKNOD"
 
 docker run -d --name=$app --restart always $options $image 1>&2
 RT=$?


### PR DESCRIPTION
Hi, I finally fixed issue #1 : "NextCloud tries to connect to https://localhost:31000/"

Collabora was not passed any "server_name" (the collabora domain) and thus guessing it trough the what it got from Http (Host/Port).

Nginx configuration was also uncomplete.
I used the one from : 
https://www.marksei.com/how-to-integrate-collabora-online-in-nextcloud/

I am surprised this app ever worked for anyone in those conditions.

Please be aware that I also add to restart the Docker service following this bug : 
https://help.nextcloud.com/t/failure-please-ensure-the-file-type-is-supported-and-not-corrupted/8031/5?u=ajdunevent
